### PR TITLE
feedback: add bug classification to feedback template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,0 +1,68 @@
+## General Feedback
+
+### Metadata (for FOCUS Staff or Maintainers)
+```
+Recommended Labels: feedback, needs triage
+Suggested Assignee: @matt-cowsert
+```
+
+_Use this template to report bugs in existing spec behavior, small corrections, or suggestions that improve clarity, accuracy, or consistency in the FOCUS Specification._
+
+> **Not sure which template to use?**
+> If your suggestion involves **adding, changing, or removing a data field, label, or structure**, please submit a [Feature Request](../feature_request_template.md) instead.
+>
+> **Found incorrect behavior in the current spec?** Select "Bug" below. These are prioritized for immediate triage.
+
+---
+
+### Submitting Organization (Optional)
+If you're submitting on behalf of an organization, list it here.
+
+```
+e.g., BigCloud Inc.
+```
+
+---
+
+### Feedback Summary
+Describe the issue or suggestion. Be specific and actionable.
+
+```
+e.g., Typo in field `skuDescription` definition — should say "metered" instead of "metred".
+```
+
+---
+
+### Type of Feedback
+Select the category that best describes your suggestion:
+
+- [ ] Bug — incorrect or contradictory behavior in the current spec
+- [ ] Typo or grammar
+  _e.g., spelling, punctuation, or wording errors_
+- [ ] Clarity improvement
+  _e.g., a confusing explanation, unclear table header, ambiguous instruction_
+- [ ] Field naming or label inconsistency
+  _e.g., same concept referred to as `region` in one section and `location` in another_
+- [ ] Definition or behavior inconsistency
+  _e.g., a metric described differently across two pages or files_
+- [ ] Minor correction (non-breaking)
+  _e.g., formatting tweaks, broken links, outdated references_
+- [ ] Other (please explain)
+
+---
+
+### Affected Section or Field (Optional)
+If known, indicate where the issue appears (file path, section, or data field name).
+
+```
+e.g., /definitions/UsageRecord or spec.md#sku-capacity
+```
+
+---
+
+### Additional Notes (Optional)
+Include any extra context, examples, or links that may help maintainers understand the issue.
+
+```
+Anything else worth sharing?
+```

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -6,12 +6,10 @@ Recommended Labels: feedback, needs triage
 Suggested Assignee: @matt-cowsert
 ```
 
-_Use this template to report bugs in existing spec behavior, small corrections, or suggestions that improve clarity, accuracy, or consistency in the FOCUS Specification._
+_Use this template to report corrections, clarity improvements, or bugs in the FOCUS Specification._
 
 > **Not sure which template to use?**
 > If your suggestion involves **adding, changing, or removing a data field, label, or structure**, please submit a [Feature Request](../feature_request_template.md) instead.
->
-> **Found incorrect behavior in the current spec?** Select "Bug" below. These are prioritized for immediate triage.
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,158 +1,62 @@
-name: "Feedback on Unsupported Features, Use Cases, and Existing FOCUS Spec"
-description: "Provide feedback on unsupported FinOps features, use cases, or scenarios, as well as on the existing FOCUS specification content. Avoid sharing proprietary information."
-title: "[FEEDBACK]: "
-labels:
-  - "feedback"
-assignees:
-  - "shawnalpay"
-  - "jpradocueva"
+name: "General Feedback"
+description: Suggest minor corrections, clarity improvements, or report bugs in the FOCUS Specification.
+title: "[Feedback] <Brief description of issue>"
+labels: ["feedback", "needs triage"]
+assignees: ["matt-cowsert"]
 body:
   - type: markdown
     attributes:
       value: |
-        ---
-        ### **Template Usage Notes**:
-        1. All fields marked as **mandatory** [*] must be filled before submission.
-        2. For **Supporting Data/Documentation**, ensure that linked files are accessible to relevant stakeholders.
-        3. If you wish to file a bug report using the markdown version of this issue template, please click [here](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec/issues/new?template=feedback.md)
+        _Use this form to report bugs in existing spec behavior, small corrections, or suggestions that improve clarity, accuracy, or consistency._
 
+        ⚠️ **Feature-related suggestions should be submitted via the Feature Request template instead.**
+        🐛 **Found incorrect behavior in the current spec? Select "Bug" below — these are prioritized for immediate triage.**
 
-  - type: markdown
+  - type: input
+    id: organization
     attributes:
-      value: |
-        ## 1. **Problem statement**
-        Describe the problem or opportunity that this issue addresses. Explain the context and why it needs resolution.
-
-  - type: textarea
-    id: issue-summary
-    attributes:
-      label: Summary
-      description: "Briefly describe the problem or opportunity that this issue addresses and why it needs resolution."
-      placeholder: "Briefly describe the problem or opportunity that needs resolution."
-    validations:
-      required: true
-
-  - type: dropdown
-    id: issue-area
-    attributes:
-      label: Which area does this issue relate to?
-      description: "Select one of the provided options:"
-      options:
-        - 'A: Missing FinOps feature, use case, or scenario'
-        - 'B: Existing FOCUS specification content'
-        - 'C: Other'
-    validations:
-      required: true
-
-  - type: textarea
-    id: issue-description
-    attributes:
-      label: Detailed Description
-      description: "Provide a detailed description of the problem or opportunity. Add context or any other relevant information that may help in addressing this issue."
-      placeholder: "Provide a comprehensive description of the the problem or opportunity, including context and any relevant details."
-    validations:
-      required: true
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 2. **Use Cases**
-        Please describe the use cases, whether FinOps-related or otherwise, that cannot be performed with the existing specification unless this issue is addressed.
-
-  - type: textarea
-    id: use_cases
-    attributes:
-      label: What use cases, FinOps or others, can't be performed with the existing specification unless this issue is addressed?
-      description: "Provide detailed descriptions of the use cases that can't be performed unless this issue is addressed."
-      placeholder: "List the specific use cases that can't be performed due to the existing limitations."
-    validations:
-      required: true
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 3. **FinOps Personas**
-        List the FinOps personas this issue relates to.
-
-  - type: textarea
-    id: finops-personas
-    attributes:
-      label: Which FinOps personas does this issue relate to?
-      description: "Indicate which FinOps personas this issue relates to."
-      placeholder: "e.g., Practitioner, Executive, Finance, Engineering, Procurement, Operations, etc."
-    validations:
-      required: true
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 4. **Providers**
-        List provider groups or specific providers this issue relates to.
-
-  - type: textarea
-    id: providers
-    attributes:
-      label: Which provider groups or specific providers does this issue relate to?
-      description: "List provider groups (e.g., CSPs, SaaS) separated by semicolons (`;`), and specific providers within those groups separated by commas (`,`). If the issue applies to all providers within a group, you can simply specify the group name (e.g., 'All CSPs')."
-      placeholder: "e.g., All CSPs; SaaS: Snowflake, Salesforce"
-    validations:
-      required: true
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 5. **Criticality Scale**
-        Indicate how critical this issue or feature request is for your organization using the scale provided below.
-
-  - type: dropdown
-    id: criticality-scale
-    attributes:
-      label: On a scale of 1 - 4, how critical is this for your organization? 
-      description: "Select one of the provided options."
-      options:
-        - '1: Critical - Blocks my organization from adopting FOCUS'
-        - '2: Important - Ideally resolved within the next 3-6 months'
-        - '3: Important - Ideally resolved within the next 6-12 months'
-        - '4: Suggestion - Resolution not urgent'
-    validations:
-      required: true
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 6. **Objective**
-        State the objective of this feedback. 
-        - What outcome is expected?
-        - Define how success will be measured (e.g., metrics and KPIs).
-
-  - type: textarea
-    id: objective
-    attributes:
-      label: "Objective"
-      description: "Outline the expected outcome and success criteria."
-      placeholder: "Outline the desired outcome and any metrics or KPIs to measure success."
-    validations:
-      required: false
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 7. **Supporting Data/Documentation**
-
-  - type: textarea
-    id: data_examples
-    attributes:
-      label: "Data Examples"
-      description: "Provide links to relevant sample data or attach data extracts that support your feedback. Ensure data is anonymized and does not include sensitive or proprietary information."
-      placeholder: "Add link(s) to sample data or attach extracts that support your feedback."
+      label: Submitting Organization (Optional)
+      description: If submitting on behalf of a company, enter it here.
+      placeholder: e.g., BigCloud Inc.
     validations:
       required: false
 
   - type: textarea
-    id: issue_pr_references
+    id: feedback_summary
     attributes:
-      label: "Issues, PRs, or Other References"
-      description: "Provide links to any relevant GitHub issues, pull requests, or other applicable references."
-      placeholder: "Add links to any relevant GitHub issues, pull requests, or other applicable references."
+      label: Feedback Summary
+      description: Be specific and actionable.
+      placeholder: e.g., Typo in field `skuDescription` — should say "metered" instead of "metred".
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: feedback_type
+    attributes:
+      label: Type of Feedback
+      description: Select the option that best describes your suggestion.
+      options:
+        - label: "Bug — incorrect or contradictory behavior in the current spec"
+        - label: Typo or grammar
+        - label: Clarity improvement
+        - label: Field naming or label inconsistency
+        - label: Definition or behavior inconsistency
+        - label: "Minor correction (non-breaking)"
+        - label: Other
+
+  - type: input
+    id: affected_section
+    attributes:
+      label: Affected Section or Field (Optional)
+      placeholder: e.g., /definitions/UsageRecord or spec.md#sku-capacity
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_notes
+    attributes:
+      label: Additional Notes (Optional)
+      description: Add any extra context, examples, or links here.
+      placeholder: Anything else worth sharing?
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -9,8 +9,8 @@ body:
       value: |
         _Use this form to report bugs in existing spec behavior, small corrections, or suggestions that improve clarity, accuracy, or consistency._
 
-        ⚠️ **Feature-related suggestions should be submitted via the Feature Request template instead.**
-        🐛 **Found incorrect behavior in the current spec? Select "Bug" below — these are prioritized for immediate triage.**
+        **Feature-related suggestions should be submitted via the Feature Request template instead.**
+        **Found incorrect behavior in the current spec? Select "Bug" below — these are prioritized for immediate triage.**
 
   - type: input
     id: organization

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -7,10 +7,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        _Use this form to report bugs in existing spec behavior, small corrections, or suggestions that improve clarity, accuracy, or consistency._
+        _Use this form to report corrections, clarity improvements, or bugs in the FOCUS Specification._
 
         **Feature-related suggestions should be submitted via the Feature Request template instead.**
-        **Found incorrect behavior in the current spec? Select "Bug" below — these are prioritized for immediate triage.**
 
   - type: input
     id: organization


### PR DESCRIPTION
## Summary
- Replaces the legacy feedback template with the current FOCUS_Spec version
- Adds "Bug — incorrect or contradictory behavior in the current spec" as the first option in the Type of Feedback checklist
- Updates intro text to explicitly call out bugs as a use case for this form

## Context
From the March 9 maintainers meeting: bugs in existing spec behavior should route through the feedback template (not the FR template) for immediate triage. The current template had no explicit bug classification option.

## Test plan
- [ ] Create a new issue using the feedback template and verify the bug checkbox appears
- [ ] Confirm all other feedback type options render correctly
- [ ] Validate that the template renders properly in the issue creation form

🤖 Generated with [Claude Code](https://claude.com/claude-code)